### PR TITLE
Post tea subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -4,4 +4,14 @@ class Api::V1::SubscriptionsController < ApplicationController
     subscriptions = customer.subscriptions
     render json: SubscriptionSerializer.new(subscriptions)
   end
+
+  def create
+    subscription = Subscription.create!(subscription_params)
+    render json: SubscriptionSerializer.new(subscription), status: 201
+  end
+
+  private
+  def subscription_params
+    params.permit(:title, :price, :frequency, :customer_id, :tea_id)
+  end
 end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -6,8 +6,13 @@ class Api::V1::SubscriptionsController < ApplicationController
   end
 
   def create
-    subscription = Subscription.create!(subscription_params)
-    render json: SubscriptionSerializer.new(subscription), status: 201
+    subscription = Subscription.new(subscription_params)
+
+    if subscription.save
+      render json: SubscriptionSerializer.new(subscription), status: 201
+    else
+      render json: {error: subscription.errors.full_messages.to_sentence}, status: 400
+    end
   end
 
   private

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,6 +3,8 @@ class Subscription < ApplicationRecord
   belongs_to :customer
 
   validates_presence_of :title, :price, :status, :frequency
+  validates_numericality_of :price
+  validates :frequency, inclusion: { in: ["Yearly", "Monthly", "Weekly"] }
 
   enum status: [:active, :cancelled]
 end

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -2,5 +2,5 @@ class SubscriptionSerializer
   include JSONAPI::Serializer
 
   set_type :subscription
-  attributes :title, :price, :status, :frequency
+  attributes :title, :price, :status, :frequency, :customer_id, :tea_id
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       resources :customers do
         resources :subscriptions, only: [:index]
       end
+      resources :subscriptions, only: [:create]
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,27 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+Subscription.destroy_all
+Tea.destroy_all
+Customer.destroy_all
+
+customer_1 = Customer.create!(first_name: "Bob", last_name: "Smith", email: "bs@bs.com", address: "123 Main St")
+customer_2 = Customer.create!(first_name: "Sally", last_name: "Smith", email: "ss@ss.com", address: "123 Main St")
+customer_3 = Customer.create!(first_name: "Joe", last_name: "Smith", email: "js@js.com", address: "789 Main St")
+customer_4 = Customer.create!(first_name: "Dan", last_name: "Smith", email: "ds@ds.com", address: "789 Main St")
+
+tea_1 = Tea.create!(title: "Green Tea", description: "Green tea is great.", temperature: 180, brew_time: 3)
+tea_2 = Tea.create!(title: "Black Tea", description: "Black tea is great.", temperature: 200, brew_time: 5)
+tea_3 = Tea.create!(title: "Oolong Tea", description: "Oolong tea is great.", temperature: 190, brew_time: 4)
+tea_4 = Tea.create!(title: "White Tea", description: "White tea is great.", temperature: 185, brew_time: 3)
+
+sub_1 = Subscription.create!(title: "Green Tea Monthly", price: 10.00, status: 0, frequency: "Monthly", tea_id: tea_1.id, customer_id: customer_1.id)
+sub_2 = Subscription.create!(title: "Black Tea Monthly", price: 10.00, status: 0, frequency: "Monthly", tea_id: tea_2.id, customer_id: customer_1.id)
+sub_3 = Subscription.create!(title: "Oolong Tea Monthly", price: 20.00, status: 1, frequency: "Monthly", tea_id: tea_3.id, customer_id: customer_1.id)
+sub_4 = Subscription.create!(title: "White Tea Weekly", price: 50.00, status: 0, frequency: "Weekly", tea_id: tea_4.id, customer_id: customer_1.id)
+sub_5 = Subscription.create!(title: "Green Tea Yearly", price: 2.00, status: 0, frequency: "Yearly", tea_id: tea_1.id, customer_id: customer_2.id)
+sub_6 = Subscription.create!(title: "Oolong Tea Weekly", price: 14.00, status: 1, frequency: "Weekly", tea_id: tea_3.id, customer_id: customer_2.id)
+sub_7 = Subscription.create!(title: "Black Tea Monthly", price: 10.00, status: 0, frequency: "Monthly", tea_id: tea_2.id, customer_id: customer_3.id)
+sub_8 = Subscription.create!(title: "Green Tea Monthly", price: 10.00, status: 0, frequency: "Monthly", tea_id: tea_1.id, customer_id: customer_4.id)
+sub_9 = Subscription.create!(title: "Black Tea Monthly", price: 10.00, status: 0, frequency: "Monthly", tea_id: tea_2.id, customer_id: customer_4.id)
+sub_10 = Subscription.create!(title: "Oolong Tea Monthly", price: 20.00, status: 1, frequency: "Monthly", tea_id: tea_3.id, customer_id: customer_4.id)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -11,5 +11,7 @@ RSpec.describe Subscription, type: :model do
     it { should validate_presence_of :price }
     it { should validate_presence_of :status }
     it { should validate_presence_of :frequency }
+    it { should validate_numericality_of :price }
+    it { should validate_inclusion_of(:frequency).in_array(["Yearly", "Monthly", "Weekly"]) }
   end
 end

--- a/spec/requests/api/v1/subscriptions/create_spec.rb
+++ b/spec/requests/api/v1/subscriptions/create_spec.rb
@@ -73,7 +73,23 @@ RSpec.describe "Create Subscription API" do
       end
 
       it "returns a 400 error if any parameter is missing" do
+        customer = create(:customer)
+        tea = create(:tea)
 
+        subscription_params = {
+          price: 10.00,
+          frequency: "Monthly",
+          customer_id: customer.id,
+          tea_id: tea.id
+        }
+
+        post "/api/v1/subscriptions", params: subscription_params
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        response_json = JSON.parse(response.body, symbolize_names: true)
+        expect(response_json[:error]).to eq("Title can't be blank")
       end
 
       it "returns a 400 error if the price is not a number" do

--- a/spec/requests/api/v1/subscriptions/create_spec.rb
+++ b/spec/requests/api/v1/subscriptions/create_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Create Subscription API" do
         expect(response_json[:error]).to eq("Tea must exist")
       end
 
-      it "returns a 400 error if any parameter is missing" do
+      it "returns a 400 error if the title parameter is missing" do
         customer = create(:customer)
         tea = create(:tea)
 
@@ -90,6 +90,86 @@ RSpec.describe "Create Subscription API" do
 
         response_json = JSON.parse(response.body, symbolize_names: true)
         expect(response_json[:error]).to eq("Title can't be blank")
+      end
+
+      it "returns a 400 error if the price parameter is missing" do
+        customer = create(:customer)
+        tea = create(:tea)
+
+        subscription_params = {
+          title: "My Monthly Tea Subscription",
+          frequency: "Monthly",
+          customer_id: customer.id,
+          tea_id: tea.id
+        }
+
+        post "/api/v1/subscriptions", params: subscription_params
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        response_json = JSON.parse(response.body, symbolize_names: true)
+        expect(response_json[:error]).to eq("Price can't be blank and Price is not a number")
+      end
+
+      it "returns a 400 error if the frequency parameter is missing" do
+        customer = create(:customer)
+        tea = create(:tea)
+
+        subscription_params = {
+          title: "My Monthly Tea Subscription",
+          price: 10.00,
+          customer_id: customer.id,
+          tea_id: tea.id
+        }
+
+        post "/api/v1/subscriptions", params: subscription_params
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        response_json = JSON.parse(response.body, symbolize_names: true)
+        expect(response_json[:error]).to eq("Frequency can't be blank and Frequency is not included in the list")
+      end
+
+      it "returns a 400 error if the customer_id parameter is missing" do
+        customer = create(:customer)
+        tea = create(:tea)
+
+        subscription_params = {
+          title: "My Monthly Tea Subscription",
+          price: 10.00,
+          frequency: "Monthly",
+          tea_id: tea.id
+        }
+
+        post "/api/v1/subscriptions", params: subscription_params
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        response_json = JSON.parse(response.body, symbolize_names: true)
+        expect(response_json[:error]).to eq("Customer must exist")
+      end
+
+      it "returns a 400 error if the tea_id parameter is missing" do
+        customer = create(:customer)
+        tea = create(:tea)
+
+        subscription_params = {
+          title: "My Monthly Tea Subscription",
+          price: 10.00,
+          frequency: "Monthly",
+          customer_id: customer.id
+        }
+
+        post "/api/v1/subscriptions", params: subscription_params
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        response_json = JSON.parse(response.body, symbolize_names: true)
+        expect(response_json[:error]).to eq("Tea must exist")
       end
 
       it "returns a 400 error if the price is not a number" do
@@ -113,12 +193,25 @@ RSpec.describe "Create Subscription API" do
         expect(response_json[:error]).to eq("Price is not a number")
       end
 
-      it "returns a 4004 error if the frequency is not valid" do
+      it "returns a 400 error if the frequency is not valid" do
+        customer = create(:customer)
+        tea = create(:tea)
 
-      end
+        subscription_params = {
+          title: "My Monthly Tea Subscription",
+          price: 10.00,
+          frequency: "Daily",
+          customer_id: customer.id,
+          tea_id: tea.id
+        }
 
-      it "returns a 400 error if the customer already has a subscription to that tea" do
+        post "/api/v1/subscriptions", params: subscription_params
 
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        response_json = JSON.parse(response.body, symbolize_names: true)
+        expect(response_json[:error]).to eq("Frequency is not included in the list")
       end
     end
   end

--- a/spec/requests/api/v1/subscriptions/create_spec.rb
+++ b/spec/requests/api/v1/subscriptions/create_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Create Subscription API" do
+  describe "POST /api/v1/subscriptions" do
+    describe "Happy Path" do
+      it "creates a new subscription" do
+        customer = create(:customer)
+        tea = create(:tea)
+
+        subscription_params = {
+          title: "My Monthly Tea Subscription",
+          price: 10.00,
+          frequency: "Monthly",
+          customer_id: customer.id,
+          tea_id: tea.id
+        }
+
+        post "/api/v1/subscriptions", params: subscription_params
+
+        expect(response).to be_successful
+        expect(response.status).to eq(201)
+
+        subscription = JSON.parse(response.body, symbolize_names: true)
+
+        expect(subscription[:data][:attributes][:title]).to eq(subscription_params[:title])
+        expect(subscription[:data][:attributes][:price]).to eq(subscription_params[:price])
+        expect(subscription[:data][:attributes][:status]).to eq(subscription_params[:status])
+        expect(subscription[:data][:attributes][:frequency]).to eq(subscription_params[:frequency])
+        expect(subscription[:data][:attributes][:customer_id]).to eq(subscription_params[:customer_id])
+        expect(subscription[:data][:attributes][:tea_id]).to eq(subscription_params[:tea_id])
+      end
+    end
+
+    describe "Sad Path" do
+
+    end
+  end
+end

--- a/spec/requests/api/v1/subscriptions/create_spec.rb
+++ b/spec/requests/api/v1/subscriptions/create_spec.rb
@@ -47,13 +47,29 @@ RSpec.describe "Create Subscription API" do
 
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
-        
+
         response_json = JSON.parse(response.body, symbolize_names: true)
         expect(response_json[:error]).to eq("Customer must exist")
       end
 
       it "returns a 400 error if the tea is not found" do
+        customer = create(:customer)
 
+        subscription_params = {
+          title: "My Monthly Tea Subscription",
+          price: 10.00,
+          frequency: "Monthly",
+          customer_id: customer.id,
+          tea_id: 1
+        }
+
+        post "/api/v1/subscriptions", params: subscription_params
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        response_json = JSON.parse(response.body, symbolize_names: true)
+        expect(response_json[:error]).to eq("Tea must exist")
       end
 
       it "returns a 400 error if any parameter is missing" do

--- a/spec/requests/api/v1/subscriptions/create_spec.rb
+++ b/spec/requests/api/v1/subscriptions/create_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "Create Subscription API" do
         subscription = JSON.parse(response.body, symbolize_names: true)
 
         expect(subscription[:data][:attributes][:title]).to eq(subscription_params[:title])
-        expect(subscription[:data][:attributes][:price]).to eq(subscription_params[:price])
-        expect(subscription[:data][:attributes][:status]).to eq(subscription_params[:status])
+        expect(subscription[:data][:attributes][:price]).to eq(subscription_params[:price].to_s)
+        expect(subscription[:data][:attributes][:status]).to eq("active")
         expect(subscription[:data][:attributes][:frequency]).to eq(subscription_params[:frequency])
         expect(subscription[:data][:attributes][:customer_id]).to eq(subscription_params[:customer_id])
         expect(subscription[:data][:attributes][:tea_id]).to eq(subscription_params[:tea_id])
@@ -32,7 +32,45 @@ RSpec.describe "Create Subscription API" do
     end
 
     describe "Sad Path" do
+      it "returns a 400 error if the customer is not found" do
+        tea = create(:tea)
 
+        subscription_params = {
+          title: "My Monthly Tea Subscription",
+          price: 10.00,
+          frequency: "Monthly",
+          customer_id: 1,
+          tea_id: tea.id
+        }
+
+        post "/api/v1/subscriptions", params: subscription_params
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+        
+        response_json = JSON.parse(response.body, symbolize_names: true)
+        expect(response_json[:error]).to eq("Customer must exist")
+      end
+
+      it "returns a 400 error if the tea is not found" do
+
+      end
+
+      it "returns a 400 error if any parameter is missing" do
+
+      end
+
+      it "returns a 400 error if the price is not a number" do
+
+      end
+
+      it "returns a 4004 error if the frequency is not valid" do
+
+      end
+
+      it "returns a 400 error if the customer already has a subscription to that tea" do
+
+      end
     end
   end
 end

--- a/spec/requests/api/v1/subscriptions/create_spec.rb
+++ b/spec/requests/api/v1/subscriptions/create_spec.rb
@@ -93,7 +93,24 @@ RSpec.describe "Create Subscription API" do
       end
 
       it "returns a 400 error if the price is not a number" do
+        customer = create(:customer)
+        tea = create(:tea)
 
+        subscription_params = {
+          title: "My Monthly Tea Subscription",
+          price: "ten dollars",
+          frequency: "Monthly",
+          customer_id: customer.id,
+          tea_id: tea.id
+        }
+
+        post "/api/v1/subscriptions", params: subscription_params
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        response_json = JSON.parse(response.body, symbolize_names: true)
+        expect(response_json[:error]).to eq("Price is not a number")
       end
 
       it "returns a 4004 error if the frequency is not valid" do

--- a/spec/requests/api/v1/subscriptions/index_spec.rb
+++ b/spec/requests/api/v1/subscriptions/index_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe "Customer's Subscriptions Index API" do
           expect(subscription[:attributes]).to have_key(:price)
           expect(subscription[:attributes]).to have_key(:status)
           expect(subscription[:attributes]).to have_key(:frequency)
+          expect(subscription[:attributes]).to have_key(:customer_id)
+          expect(subscription[:attributes]).to have_key(:tea_id)
         end
 
         get "/api/v1/customers/#{customer_2.id}/subscriptions"


### PR DESCRIPTION
This pull request added the ability to POST a new tea subscription for a specified customer and tea. It has the ability to handle sad paths for non-existent customer or tea, as well as any missing parameter. 

This pull request also added subscription model validations for numericality of price, and frequency type to only be (Yearly, Monthly, or Weekly)