### PR TITLE
Delete subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -15,6 +15,13 @@ class Api::V1::SubscriptionsController < ApplicationController
     end
   end
 
+  def destroy
+    subscription = Subscription.find(params[:id])
+    subscription.cancelled!
+
+    render json: SubscriptionSerializer.new(subscription), status: 200
+  end
+
   private
   def subscription_params
     params.permit(:title, :price, :frequency, :customer_id, :tea_id)

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -17,9 +17,13 @@ class Api::V1::SubscriptionsController < ApplicationController
 
   def destroy
     subscription = Subscription.find(params[:id])
-    subscription.cancelled!
 
-    render json: SubscriptionSerializer.new(subscription), status: 200
+    if subscription.cancelled?
+      render json: {error: "Subscription is already cancelled"}, status: 400
+    else
+      subscription.cancelled!
+      render json: SubscriptionSerializer.new(subscription), status: 200
+    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
       resources :customers do
         resources :subscriptions, only: [:index]
       end
-      resources :subscriptions, only: [:create]
+      resources :subscriptions, only: [:create, :destroy]
     end
   end
 end

--- a/spec/requests/api/v1/subscriptions/create_spec.rb
+++ b/spec/requests/api/v1/subscriptions/create_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe "Create Subscription API" do
         expect(response).to be_successful
         expect(response.status).to eq(201)
 
-        subscription = JSON.parse(response.body, symbolize_names: true)
+        sub_response = JSON.parse(response.body, symbolize_names: true)
 
-        expect(subscription[:data][:attributes][:title]).to eq(subscription_params[:title])
-        expect(subscription[:data][:attributes][:price]).to eq(subscription_params[:price].to_s)
-        expect(subscription[:data][:attributes][:status]).to eq("active")
-        expect(subscription[:data][:attributes][:frequency]).to eq(subscription_params[:frequency])
-        expect(subscription[:data][:attributes][:customer_id]).to eq(subscription_params[:customer_id])
-        expect(subscription[:data][:attributes][:tea_id]).to eq(subscription_params[:tea_id])
+        expect(sub_response[:data][:attributes][:title]).to eq(subscription_params[:title])
+        expect(sub_response[:data][:attributes][:price]).to eq(subscription_params[:price].to_s)
+        expect(sub_response[:data][:attributes][:status]).to eq("active")
+        expect(sub_response[:data][:attributes][:frequency]).to eq(subscription_params[:frequency])
+        expect(sub_response[:data][:attributes][:customer_id]).to eq(subscription_params[:customer_id])
+        expect(sub_response[:data][:attributes][:tea_id]).to eq(subscription_params[:tea_id])
       end
     end
 
@@ -48,8 +48,8 @@ RSpec.describe "Create Subscription API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
 
-        response_json = JSON.parse(response.body, symbolize_names: true)
-        expect(response_json[:error]).to eq("Customer must exist")
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Customer must exist")
       end
 
       it "returns a 400 error if the tea is not found" do
@@ -68,8 +68,8 @@ RSpec.describe "Create Subscription API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
 
-        response_json = JSON.parse(response.body, symbolize_names: true)
-        expect(response_json[:error]).to eq("Tea must exist")
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Tea must exist")
       end
 
       it "returns a 400 error if the title parameter is missing" do
@@ -88,8 +88,8 @@ RSpec.describe "Create Subscription API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
 
-        response_json = JSON.parse(response.body, symbolize_names: true)
-        expect(response_json[:error]).to eq("Title can't be blank")
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Title can't be blank")
       end
 
       it "returns a 400 error if the price parameter is missing" do
@@ -108,8 +108,8 @@ RSpec.describe "Create Subscription API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
 
-        response_json = JSON.parse(response.body, symbolize_names: true)
-        expect(response_json[:error]).to eq("Price can't be blank and Price is not a number")
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Price can't be blank and Price is not a number")
       end
 
       it "returns a 400 error if the frequency parameter is missing" do
@@ -128,8 +128,8 @@ RSpec.describe "Create Subscription API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
 
-        response_json = JSON.parse(response.body, symbolize_names: true)
-        expect(response_json[:error]).to eq("Frequency can't be blank and Frequency is not included in the list")
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Frequency can't be blank and Frequency is not included in the list")
       end
 
       it "returns a 400 error if the customer_id parameter is missing" do
@@ -148,8 +148,8 @@ RSpec.describe "Create Subscription API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
 
-        response_json = JSON.parse(response.body, symbolize_names: true)
-        expect(response_json[:error]).to eq("Customer must exist")
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Customer must exist")
       end
 
       it "returns a 400 error if the tea_id parameter is missing" do
@@ -168,8 +168,8 @@ RSpec.describe "Create Subscription API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
 
-        response_json = JSON.parse(response.body, symbolize_names: true)
-        expect(response_json[:error]).to eq("Tea must exist")
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Tea must exist")
       end
 
       it "returns a 400 error if the price is not a number" do
@@ -189,8 +189,8 @@ RSpec.describe "Create Subscription API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
 
-        response_json = JSON.parse(response.body, symbolize_names: true)
-        expect(response_json[:error]).to eq("Price is not a number")
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Price is not a number")
       end
 
       it "returns a 400 error if the frequency is not valid" do
@@ -210,8 +210,8 @@ RSpec.describe "Create Subscription API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(400)
 
-        response_json = JSON.parse(response.body, symbolize_names: true)
-        expect(response_json[:error]).to eq("Frequency is not included in the list")
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Frequency is not included in the list")
       end
     end
   end

--- a/spec/requests/api/v1/subscriptions/destroy_spec.rb
+++ b/spec/requests/api/v1/subscriptions/destroy_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Destroy Subscription API" do
+  describe "DELETE /api/v1/subscriptions/:id" do
+    describe "Happy Path" do
+      it "deletes a subscription" do
+        customer = create(:customer)
+        tea = create(:tea)
+        subscription = create(:subscription, customer: customer, tea: tea, status: 0)
+
+        expect(subscription.status).to eq("active")
+
+        delete "/api/v1/subscriptions/#{subscription.id}"
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+
+        expect(subscription.status).to eq("cancelled")
+
+        sub_response = JSON.parse(response.body, symbolize_names: true)
+
+        expect(sub_response[:data][:attributes][:status]).to eq("cancelled")
+        expect(sub_response[:data][:attributes][:title]).to eq(subscription.title)
+        expect(sub_response[:data][:attributes][:price]).to eq(subscription.price.to_s)
+        expect(sub_response[:data][:attributes][:frequency]).to eq(subscription.frequency)
+        expect(sub_response[:data][:attributes][:customer_id]).to eq(subscription.customer_id)
+        expect(sub_response[:data][:attributes][:tea_id]).to eq(subscription.tea_id)
+      end
+    end
+
+    describe "Sad Path" do
+      xit "returns a 404 if the subscription is not found" do
+        delete "/api/v1/subscriptions/1"
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/subscriptions/destroy_spec.rb
+++ b/spec/requests/api/v1/subscriptions/destroy_spec.rb
@@ -38,7 +38,23 @@ RSpec.describe "Destroy Subscription API" do
         expect(response.status).to eq(404)
 
         error_response = JSON.parse(response.body, symbolize_names: true)
+
         expect(error_response[:error]).to eq("Customer not found")
+      end
+
+      it "returns a 404 if the subscription is already cancelled" do
+        customer = create(:customer)
+        tea = create(:tea)
+        subscription = create(:subscription, customer: customer, tea: tea, status: 1)
+
+        delete "/api/v1/subscriptions/#{subscription.id}"
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+
+        error_response = JSON.parse(response.body, symbolize_names: true)
+
+        expect(error_response[:error]).to eq("Subscription is already cancelled")
       end
     end
   end

--- a/spec/requests/api/v1/subscriptions/destroy_spec.rb
+++ b/spec/requests/api/v1/subscriptions/destroy_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe "Destroy Subscription API" do
         expect(response).to be_successful
         expect(response.status).to eq(200)
 
+        subscription = Subscription.find_by(id: subscription.id)
+
         expect(subscription.status).to eq("cancelled")
 
         sub_response = JSON.parse(response.body, symbolize_names: true)
@@ -29,11 +31,14 @@ RSpec.describe "Destroy Subscription API" do
     end
 
     describe "Sad Path" do
-      xit "returns a 404 if the subscription is not found" do
+      it "returns a 404 if the subscription is not found" do
         delete "/api/v1/subscriptions/1"
 
         expect(response).to_not be_successful
         expect(response.status).to eq(404)
+
+        error_response = JSON.parse(response.body, symbolize_names: true)
+        expect(error_response[:error]).to eq("Customer not found")
       end
     end
   end

--- a/spec/requests/api/v1/subscriptions/index_spec.rb
+++ b/spec/requests/api/v1/subscriptions/index_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe "Customer's Subscriptions Index API" do
         expect(response).to_not be_successful
         expect(response.status).to eq(404)
 
-        error = JSON.parse(response.body, symbolize_names: true)
+        error_response = JSON.parse(response.body, symbolize_names: true)
 
-        expect(error[:error]).to eq("Customer not found")
+        expect(error_response[:error]).to eq("Customer not found")
       end
 
       it "returns an empty array if the customer has no subscriptions" do


### PR DESCRIPTION
This pull request adds a delete subscription request and associated tests. This includes sad paths for when a subscription doesn't exist and for when a subscription has already previously been cancelled.